### PR TITLE
add: tests for coinbase string extraction

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,6 +59,35 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_extract_coinbase_string() {
+        let test_cases = vec![
+            (   // mainnet 82f3748ef4ffc2acfefbbc682adf34532eef41e13c4819085a8af611a8f118fa
+                "03a4120d04b5a2bc667c204d41524120506f6f6c207c204d61646520696e2055534120f09f87baf09f87b8207c202876303331393234293c39dbd326a3c601527b7112d4f11f911356a5e9450000000000ffffffff",
+                "f| MARA Pool | Made in USA  | (v031924)<9"
+            ),
+            (   // mainnet 9603a850d3da9f230d36d03c83eb402c18fae9754cdb528a242c96dac0187538
+                "03a3120d1b4d696e656420627920416e74506f6f6c3837349f00010293f49debfabe6d6d7ce2d695ffb032041ea85db181f3aea78cf47946d5e610fe32292d95db1eca551000000000000000540c00005737000000000000",
+                "Mined by AntPool874"
+            ),
+            (   // mainnet 4808de30cf5ad96fbce89f7efabcebf8222f098c51926a282472292ac9291d1d
+                "0390120d182f5669614254432f4d696e6564206279206173646c31372f2cfabe6d6d038689c77c851fb85eef5e10eade9efb405e21994412c978983b2e71881f471610000000000000001046b1dc05df138865a39bb08f551f080000000000",
+                "/ViaBTC/Mined by asdl17/,"
+            ),
+            (   // mainnet dbb5ac4b963babbaa3a7c85ef234959a702d583c09f1a609ad7f5b80cc0c064a
+                "031c120d048867bb662f466f756e6472792055534120506f6f6c202364726f70676f6c642f4892b78e0000b3b25d010000",
+                "f/Foundry USA Pool #dropgold/H"
+            ),
+        ];
+
+        for (hex, result) in test_cases {
+            assert_eq!(
+                extract_coinbase_string(&ScriptBuf::from_hex(hex).unwrap()),
+                result,
+            );
+        }
+    }
+
+    #[test]
     fn test_bip34_coinbase_block_height() {
         let test_cases = vec![
             ("07", None),


### PR DESCRIPTION
Adds a few tests.

I've also looked into https://github.com/0xB10C/stratum-observer/issues/9 while at it. It seems to me that the BIP-34 block height is not part of the extracted string. 